### PR TITLE
Updates README To Add Installation Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,18 @@ Sublime syntax highlighting for CJSX
 
 ## Installation
 
-Coming soon...
+To install this plugin from Github, follow these steps:
+
+1. Open Sublime and open "Package Control" (cmd + shift + p).
+1. Type "Add Repository"; select the result (hit enter).
+1. At the bottom of your Sublime window you will see a text input that prompts you for the Github URL.
+1. Copy and paste: "https://github.com/Guidebook/sublime-cjsx".
+1. Give Sublime a few minutes to add the repo.
+1. Open "Package Control" again (cmd + shift + p) and type "Install Package".
+1. Type "sublime cjsx"; select the result (hit enter).
+1. Give Sublime a few minutes to install the package.
+1. Open a .cjsx file and in the lower right hand corner of your Sublime window, open the syntax dropdown.
+1. Select 'CJSX' and smile.
 
 ## Credit
 


### PR DESCRIPTION
## What

Adds installation documentation to the README so others can easily download this plugin.
## Why

Help adoption.
## Testing

Follow the instructions -- assert that they work correctly (on a Mac).
