### PR TITLE
Fixed highlighting problem

### DIFF
--- a/syntax/CJSX.tmLanguage
+++ b/syntax/CJSX.tmLanguage
@@ -879,7 +879,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(&lt;/)(\2)([^&gt;]*&gt;)</string>
+			<string>(&lt;/)(\2)([^&gt;]*&gt;)|(\/&gt;)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -970,7 +970,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(&lt;/)([^&gt;]+)(&gt;)</string>
+			<string>(&lt;/)([^&gt;]+)(&gt;)|(\/&gt;)</string>
 			<key>name</key>
 			<string>tag.close.coffee</string>
 		</dict>


### PR DESCRIPTION
Previously, self-closing tags messed up highlighting...

``` javascript
<MyComponent
  key={@props.key}
/>
```

...instead, requiring a closing tag even when no children are supplied.

``` javascript
<MyComponent
  key={@props.key}
></MyComponent>
```

This patch removes the need to always provide a closing tag.
