### PR TITLE
Require a break before matching class regex

### DIFF
--- a/syntax/CJSX.sublime-syntax
+++ b/syntax/CJSX.sublime-syntax
@@ -145,7 +145,7 @@ contexts:
       scope: constant.language.null.coffee
     - match: '\b(?<!\.)(this|extends)(?!\s*[:=])\b'
       scope: variable.language.coffee
-    - match: '(class\b)\s+(@?[a-zA-Z\$_][\w\.]*)?(?:\s+(extends)\s+(@?[a-zA-Z\$\._][\w\.]*))?'
+    - match: '\b(class\b)\s+(@?[a-zA-Z\$_][\w\.]*)?(?:\s+(extends)\s+(@?[a-zA-Z\$\._][\w\.]*))?'
       scope: meta.class.coffee
       captures:
         1: storage.type.class.coffee


### PR DESCRIPTION
What: Requires a break before matching the `class` keyword, to prevent incorrectly matching when `class` appears at the end of a non-keyword function or variable.

Current behavior:
<img width="261" alt="screenshot 2017-03-01 20 03 36" src="https://cloud.githubusercontent.com/assets/1896112/23489863/7c561c56-feba-11e6-87c9-e9a202ea9581.png">

New behavior:
<img width="261" alt="screenshot 2017-03-01 20 04 04" src="https://cloud.githubusercontent.com/assets/1896112/23489870/83f9473a-feba-11e6-9491-b175df034d17.png">

Why: Fixes #5

Testing: Check out branch, copy syntax/CJSX.sublime-syntax to your Sublime Text packages folder, open a CJSX file in Sublime, and use the command palette to select the new syntax.