### PR TITLE
Match on ES6-style module keywords.

### DIFF
--- a/syntax/CJSX.sublime-syntax
+++ b/syntax/CJSX.sublime-syntax
@@ -14,6 +14,9 @@ scope: source.coffee
 contexts:
   main:
     - include: jsx
+    - match: (?<!\.)\b(?>import|export|default|from|as)\b
+      comment: "match ES6-style module keywords"
+      scope: keyword.operator.coffee
     - match: '(\([^()]*?\))\s*([=-]>)'
       comment: "match stuff like: a -> …"
       scope: meta.inline.function.coffee


### PR DESCRIPTION
What: Adds matching for ES6 keywords (import, export, etc) which are officially supported in CoffeeScript [as of 1.11.0](https://github.com/jashkenas/coffeescript/issues/3162#issuecomment-249377792).

Before:
<img width="459" alt="screenshot 2017-03-01 20 44 16" src="https://cloud.githubusercontent.com/assets/1896112/23490799/14898864-fec0-11e6-941f-6ea3bdb8442a.png">

After:
<img width="461" alt="screenshot 2017-03-01 20 44 04" src="https://cloud.githubusercontent.com/assets/1896112/23490805/1a3a982a-fec0-11e6-9bad-a19542521934.png">


Why: Improves readability when using ES6 keywords. Closes #6

Testing: Check out branch, copy syntax/CJSX.sublime-syntax to your Sublime Text packages folder, open a CJSX file in Sublime, and use the command palette to select the new syntax.