### PR TITLE
Fix incorrect matching of Express/Mocha keywords.

### DIFF
--- a/syntax/CJSX.sublime-syntax
+++ b/syntax/CJSX.sublime-syntax
@@ -131,7 +131,7 @@ contexts:
         3: entity.name.function.coffee
         4: variable.parameter.function.coffee
         5: storage.type.function.coffee
-    - match: ^\s*(describe|it|app\.(get|post|put|all|del|delete))
+    - match: ^\s*(describe|it|app\.(get|post|put|all|del|delete))[^\w]
       comment: Show well-known functions from Express and Mocha in Go To Symbol view
       push:
         - meta_scope: meta.function.symbols.coffee


### PR DESCRIPTION
I first noticed this incorrect syntax highlighting:
<img width="204" alt="screenshot 2017-05-20 18 32 00" src="https://cloud.githubusercontent.com/assets/1896112/26279791/ad2e4434-3d8a-11e7-9ab2-46c10fe2136b.png">

which I then noticed will generally match incorrectly whenever one of the keywords appears with 1+ spaces in front of it:
<img width="219" alt="screenshot 2017-05-20 18 33 20" src="https://cloud.githubusercontent.com/assets/1896112/26279797/e2f7443a-3d8a-11e7-8e87-38e536cb569a.png">

I traced the problem to [this rule](https://github.com/Guidebook/sublime-cjsx/blob/master/syntax/CJSX.sublime-syntax#L134-L140). While researching what that rule does, I found the same rule [here](https://github.com/aponxi/sublime-better-coffeescript/blob/master/CoffeeScript.tmLanguage#L353-L369) in `sublime-better-coffeescript` -- I assume `sublime-cjsx` is a derivative of that project. `sublime-better-coffeescript` had the tweak to the rule that I'm submitting in this PR, which seems to fix the problem:
<img width="228" alt="screenshot 2017-05-20 18 44 36" src="https://cloud.githubusercontent.com/assets/1896112/26279832/71bd3606-3d8c-11e7-9650-6ed491c02920.png">

PS: after merging (if this looks good), could y'all cut a new release on Package Control? I don't think that ever got done after my previous contributions :) thanks!
